### PR TITLE
Update katex-header.html

### DIFF
--- a/givre/CHANGELOG.md
+++ b/givre/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.1.2
+* Fix issue with double header menu displayed on docs.rs [#16]
+
+[#16]: https://github.com/LFDT-Lockness/givre/pull/16
+
 ## v0.1.1
 
 * Update metadata for docs.rs [#14]

--- a/givre/Cargo.toml
+++ b/givre/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "givre"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "TSS Schnorr/EdDSA implementation based on FROST"

--- a/katex-header.html
+++ b/katex-header.html
@@ -1,51 +1,38 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">
-
-<html>
-<head>
-  <link rel="stylesheet" href=
-  "https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.css"
-  integrity=
-  "sha384-RZU/ijkSsFbcmivfdRBQDtwuwVqK7GMOw6IMvKyeWL2K5UAlyp6WonmB8m7Jd0Hn"
+<link rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.css"
+  integrity="sha384-RZU/ijkSsFbcmivfdRBQDtwuwVqK7GMOw6IMvKyeWL2K5UAlyp6WonmB8m7Jd0Hn"
   crossorigin="anonymous" type="text/css">
-  <script defer src=
-  "https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.js"
-  integrity=
-  "sha384-pK1WpvzWVBQiP0/GjnvRxV4mOb0oxFuyRxJlk6vVw146n3egcN5C925NCP7a7BY8"
+<script defer
+  src="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/katex.min.js"
+  integrity="sha384-pK1WpvzWVBQiP0/GjnvRxV4mOb0oxFuyRxJlk6vVw146n3egcN5C925NCP7a7BY8"
   crossorigin="anonymous" type="text/javascript">
 </script>
-  <script defer src=
-  "https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/contrib/auto-render.min.js"
-  integrity=
-  "sha384-vZTG03m+2yp6N6BNi5iM4rW4oIwk5DfcNdFfxkk9ZWpDriOkXX8voJBFrAO7MpVl"
+<script defer
+  src="https://cdn.jsdelivr.net/npm/katex@0.13.13/dist/contrib/auto-render.min.js"
+  integrity="sha384-vZTG03m+2yp6N6BNi5iM4rW4oIwk5DfcNdFfxkk9ZWpDriOkXX8voJBFrAO7MpVl"
   crossorigin="anonymous" type="text/javascript">
 </script>
-  <script type="text/javascript">
-document.addEventListener("DOMContentLoaded", function() {
-        renderMathInElement(document.body, {
-            delimiters: [
-                {left: "$$", right: "$$", display: true},
-                {left: "\\(", right: "\\)", display: false},
-                {left: "$", right: "$", display: false},
-                {left: "\\[", right: "\\]", display: true}
-            ],
-            macros: {
-                "\\Zq": "\\mathbb{Z}_q",
-                "\\G": "\\mathbb{G}",
-                "\\T": "\\mathbb{T}",
-                "\\O": "\\mathcal{O}",
-                "\\P": "\\mathcal{P}",
-                "\\V": "\\mathcal{V}",
-                "\\H": "\\mathcal{H}",
-                "\\?": "\\stackrel{?}{=}",
-                "\\sk": "\\text{sk}",
-            },
-        });
+
+<script type="text/javascript">
+  document.addEventListener("DOMContentLoaded", function() {
+    renderMathInElement(document.body, {
+        delimiters: [
+            {left: "$$", right: "$$", display: true},
+            {left: "\\(", right: "\\)", display: false},
+            {left: "$", right: "$", display: false},
+            {left: "\\[", right: "\\]", display: true}
+        ],
+        macros: {
+            "\\Zq": "\\mathbb{Z}_q",
+            "\\G": "\\mathbb{G}",
+            "\\T": "\\mathbb{T}",
+            "\\O": "\\mathcal{O}",
+            "\\P": "\\mathcal{P}",
+            "\\V": "\\mathcal{V}",
+            "\\H": "\\mathcal{H}",
+            "\\?": "\\stackrel{?}{=}",
+        },
     });
-  </script>
+  });
+</script>
 
-  <title></title>
-</head>
-
-<body>
-</body>
-</html>


### PR DESCRIPTION
PR updates katex-header.html file to be the same across all repos. Some of them were broken and caused double header menu displayed on docs.rs. I update all repos regardless of whether the katex header was broken, to sync all repos.